### PR TITLE
Add dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,30 @@
+# compiled output
+**/target/
+workspace/
+**/bin/
+*/.settings/org.sonar.ide.eclipse.core.prefs
+.polyglot.build.properties
+.tycho-consumer-pom.xml
+
+
+# Git
+.git*
+!.git/
+
+# Markdown file
+*.md
+
+
+# IDEs and editors
+
+
+# IDE - VSCode
+.vscode/*
+.history/*
+.devcontainer/
+
+# Dockerfile
+dockerfiles/
+
+# System Files
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,9 @@
 bin/
 target/
 workspace/
+
+
+
+# VS Code
+.devcontainer
+.vscode

--- a/dockerfiles/Dockerfile.prod
+++ b/dockerfiles/Dockerfile.prod
@@ -1,0 +1,42 @@
+# Copyright (c) 2022 École Polytechnique de Montréal
+#
+# All rights reserved. This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0 which
+# accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+
+FROM tracecompass:latest as packager
+
+ENV JAVA_MINIMAL="/opt/java-minimal"
+
+RUN apk --no-cache add openjdk11-jdk openjdk11-jmods maven && \
+    # build minimal JRE
+    /usr/lib/jvm/java-11-openjdk/bin/jlink \
+    --verbose \
+    --add-modules \
+    java.base,java.sql,java.naming,java.desktop,java.management,java.security.jgss,java.instrument,jdk.unsupported \
+    --compress 2 --no-header-files --strip-debug --no-man-pages \
+    --output "$JAVA_MINIMAL"
+
+COPY ./ /app/
+
+WORKDIR /app/
+
+RUN mvn clean install -DskipTests -Dmaven.test.skip=true
+
+FROM alpine:3.16.0
+
+ENV JAVA_HOME=/opt/java-minimal
+ENV PATH="$PATH:$JAVA_HOME/bin"
+
+# Required dependency for Eclipse Trace Compass Server
+RUN apk --no-cache add libc6-compat
+
+COPY --from=packager "$JAVA_HOME" "$JAVA_HOME"
+COPY --from=packager /app/trace-server/org.eclipse.tracecompass.incubator.trace.server.product/target/products/traceserver/linux/gtk/x86_64/trace-compass-server /usr/src/tracecompass
+
+WORKDIR /usr/src/tracecompass
+EXPOSE 8080
+CMD ["./tracecompass-server"]


### PR DESCRIPTION
I made a multi stage build dockerfile to compile tracecompass.incubator and launch the trace-server on port 8080. The stage "packager" install the minimum package needed to compile tracecompass.incubator and use the image of the tracecompass. Then it will copy the project inside the container then run the "mvn clean install -DskipTests -Dmaven.test.skip=true" command to build tracecompass.incubator. After the build, it will go to the next stage and this stage will just have the bare minimum configuration to run the tracecompass-server. It will copy tracecompass-server already install into the new stage and run it on the port 8080.